### PR TITLE
fix: fixed the calculation of picnic rules key

### DIFF
--- a/src/main/java/com/github/erroraway/sonarqube/ErrorAwayDiagnosticListener.java
+++ b/src/main/java/com/github/erroraway/sonarqube/ErrorAwayDiagnosticListener.java
@@ -58,7 +58,7 @@ public class ErrorAwayDiagnosticListener implements DiagnosticListener<JavaFileO
 		String message = diagnostic.getMessage(Locale.ENGLISH);
 		String rule = parseRule(diagnostic, message);
 
-		RuleKey ruleKey = RuleKey.of(findRepository(rule), rule);
+		RuleKey ruleKey = RuleKey.of(findRepository(rule, message), rule);
 
 		int startLine = (int) diagnostic.getLineNumber();
 
@@ -148,9 +148,13 @@ public class ErrorAwayDiagnosticListener implements DiagnosticListener<JavaFileO
 		}
 	}
 
-	private String findRepository(String rule) {
+	private String findRepository(String rule, String message) {
 		if (rule.startsWith("Slf4j")) {
 			return ErrorAwayRulesDefinition.ERRORPRONE_SLF4J_REPOSITORY;
+		}
+		
+		if (message.contains("see https://error-prone.picnic.tech/bugpatterns/")) {
+			return ErrorAwayRulesDefinition.PICNIC_REPOSITORY;
 		}
 
 		switch (rule) {

--- a/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
+++ b/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
@@ -229,7 +229,8 @@ class ErrorAwaySensorTest {
         setConfigurationStringArray(ErrorAwayPlugin.MAVEN_REPOSITORIES, new String[] {"https://repo1.maven.org/maven2/"});
         setup(Path.of("com/bug/Slf4jSamples.java"));
         
-        enableRule(RuleKey.of("errorprone-slf4j", "Slf4jPlaceholderMismatch"));
+		RuleKey ruleKey = RuleKey.of("errorprone-slf4j", "Slf4jPlaceholderMismatch");
+		enableRule(ruleKey);
         setConfigurationStringArray(ErrorAwayPlugin.CLASS_PATH_MAVEN_COORDINATES, new String[]{"org.slf4j:slf4j-api:1.7.36"});
         
         // Call the sensor
@@ -237,6 +238,7 @@ class ErrorAwaySensorTest {
         sensor.execute(context);
 
         verify(context, times(1)).newIssue();
+		verify(newIssue, times(1)).forRule(ruleKey);
     }
     
     @Test
@@ -244,7 +246,8 @@ class ErrorAwaySensorTest {
         setConfigurationStringArray(ErrorAwayPlugin.MAVEN_REPOSITORIES, new String[] {"https://repo1.maven.org/maven2/"});
         setup(Path.of("com/bug/AndroidActivity.java"));
         
-        enableRule(RuleKey.of("autodispose2", "AutoDispose"));
+		RuleKey ruleKey = RuleKey.of("autodispose2", "AutoDispose");
+		enableRule(ruleKey);
         setConfigurationStringArray(ErrorAwayPlugin.CLASS_PATH_MAVEN_COORDINATES, new String[]{
                 "com.google.android:android:4.1.1.4",
                 "io.reactivex.rxjava3:rxjava:3.1.4"
@@ -255,8 +258,28 @@ class ErrorAwaySensorTest {
         sensor.execute(context);
 
         verify(context, times(1)).newIssue();
+		verify(newIssue, times(1)).forRule(ruleKey);
     }
-    
+
+	@Test
+	void analyzeWithPicnicErrorProneSupport() {
+		setConfigurationStringArray(ErrorAwayPlugin.MAVEN_REPOSITORIES, new String[]{"https://repo1.maven.org/maven2/"});
+		setup(Path.of("com/bug/PicnicErrorProneSupportSample.java"));
+
+		RuleKey ruleKey = RuleKey.of(ErrorAwayRulesDefinition.PICNIC_REPOSITORY, "IdentityConversion");
+		enableRule(ruleKey);
+		setConfigurationStringArray(
+				ErrorAwayPlugin.CLASS_PATH_MAVEN_COORDINATES,
+				new String[]{"com.google.guava:guava:31.1-jre"});
+
+		// Call the sensor
+		ErrorAwaySensor sensor = new ErrorAwaySensor(javaResourceLocator, dependencyManager, tempFolder);
+		sensor.execute(context);
+
+		verify(context, times(1)).newIssue();
+		verify(newIssue, times(1)).forRule(ruleKey);
+	}
+
     @Test
     void analyzeManyBugs() {
         setup(Path.of("com/bug/ManyBugs.java"));

--- a/src/test/resources/samples/com/bug/PicnicErrorProneSupportSample.java
+++ b/src/test/resources/samples/com/bug/PicnicErrorProneSupportSample.java
@@ -1,0 +1,15 @@
+package com.bug;
+
+import com.google.common.collect.ImmutableSet;
+import java.math.BigDecimal;
+
+public class PicnicErrorProneSupportSample {
+	static BigDecimal getNumber() {
+		return BigDecimal.valueOf(0);
+	}
+	
+	public ImmutableSet<Integer> getSet() {
+		ImmutableSet<Integer> set = ImmutableSet.of(1);
+		return ImmutableSet.copyOf(set);
+	}
+}


### PR DESCRIPTION
- Look for the picnic doc url in the error message so we can locate the rule from the correct repository.
- Upgrading Picnic error prone support to 0.6.0 breaks the unit tests until https://github.com/PicnicSupermarket/error-prone-support/pull/412 is merged and released