### PR TITLE
feature: fail the analysis when we encounter a compile error

### DIFF
--- a/src/main/java/com/github/erroraway/sonarqube/ErrorAwayCompilationException.java
+++ b/src/main/java/com/github/erroraway/sonarqube/ErrorAwayCompilationException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The ErrorAway Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.erroraway.sonarqube;
+
+/**
+ * @author gtoison
+ *
+ */
+public class ErrorAwayCompilationException extends RuntimeException {
+	private static final long serialVersionUID = 3584619279474215608L;
+
+	public ErrorAwayCompilationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/github/erroraway/sonarqube/ErrorAwayDiagnosticListener.java
+++ b/src/main/java/com/github/erroraway/sonarqube/ErrorAwayDiagnosticListener.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaFileObject;
 
@@ -134,6 +135,10 @@ public class ErrorAwayDiagnosticListener implements DiagnosticListener<JavaFileO
 			}
 
 			analysisError.save();
+
+			if (diagnostic.getKind().equals(Kind.ERROR)) {
+				throw new ErrorAwayCompilationException("Compilation error: " + diagnostic);
+			}
 
 			return false;
 		}

--- a/src/test/java/com/github/erroraway/sonarqube/ErrorAwayDiagnosticListenerTest.java
+++ b/src/test/java/com/github/erroraway/sonarqube/ErrorAwayDiagnosticListenerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -58,16 +59,17 @@ class ErrorAwayDiagnosticListenerTest {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void ignoreCompilerError() {
+	void failOnCompilerError() {
 		Diagnostic<JavaFileObject> diagnostic = mock(Diagnostic.class);
 		JavaFileObject javaFileObject = mock(JavaFileObject.class);
 
 		when(diagnostic.getCode()).thenReturn("compiler.note.deprecated.filename");
 		when(diagnostic.getSource()).thenReturn(javaFileObject);
+		when(diagnostic.getKind()).thenReturn(Kind.ERROR);
 
 		ErrorAwayDiagnosticListener listener = new ErrorAwayDiagnosticListener(context);
 
-		listener.report(diagnostic);
+		assertThrows(ErrorAwayCompilationException.class, () -> listener.report(diagnostic));
 
 		verify(context, never()).newIssue();
 	}

--- a/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
+++ b/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
@@ -17,6 +17,7 @@ package com.github.erroraway.sonarqube;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -195,9 +196,10 @@ class ErrorAwaySensorTest {
 
 		// Call the sensor
 		ErrorAwaySensor sensor = new ErrorAwaySensor(javaResourceLocator, dependencyManager, tempFolder);
-		sensor.execute(context);
+		// Javac wraps our exception in a RuntimeException
+		assertThrowsExactly(RuntimeException.class, () -> sensor.execute(context));
 
-		verify(context, times(3)).newAnalysisError();
+		verify(context, times(1)).newAnalysisError();
 	}
 
 	@Test


### PR DESCRIPTION
When we analyse a project it might happen that there's a compile error and in that case we fail to find issues. If we complete the analysis we report no issue to the SonarQube server and any existing issue is therfore marked as solved.
Instead throw an exception and let the analysis fail