### PR TITLE
Use ClassPathForMain to get the classpath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,18 +33,15 @@ jobs:
           - SONAR_SERVER_VERSION: 9.9.3.79811
             SONAR_PLUGIN_API_VERSION: 9.14.0.375
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.16.0.30901
             SONAR_SERVER_JAVA_VERSION: 17
           # 10.x 
           - SONAR_SERVER_VERSION: 10.4.0.87286
             SONAR_PLUGIN_API_VERSION: 10.6.0.2114
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.30.1.34514
             SONAR_SERVER_JAVA_VERSION: 17
-          - SONAR_SERVER_VERSION: 10.5.1.90531
+          - SONAR_SERVER_VERSION: 10.6.0.92116
             SONAR_PLUGIN_API_VERSION: 10.7.0.2191
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.34.0.35958
             SONAR_SERVER_JAVA_VERSION: 17
     steps:
       - uses: actions/checkout@v4
@@ -67,8 +64,7 @@ jobs:
           mvn -B verify \
           -Dsonar.server.version=${{ matrix.SONAR_SERVER_VERSION }} \
           -Dsonar-plugin-api.version=${{ matrix.SONAR_PLUGIN_API_VERSION }} \
-          -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }} \
-          -Dsonar-java.version=${{ matrix.SONAR_JAVA_VERSION }}
+          -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }}
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<sonar-plugin-api.version>9.14.0.375</sonar-plugin-api.version>
 		<sonar-plugin-api.groupId>org.sonarsource.api.plugin</sonar-plugin-api.groupId>
 		<sonar-commons-analyzers.version>1.10.2.456</sonar-commons-analyzers.version>
-		<sonar-java.version>6.0.0.20538</sonar-java.version>
+		<sonar-java-frontend.version>8.2.0.36672</sonar-java-frontend.version>
 		<sonar-orchestrator.version>4.7.0.1861</sonar-orchestrator.version>
 
 		<errorprone.version>2.26.1</errorprone.version>

--- a/sonar-erroraway-sonar-plugin/pom.xml
+++ b/sonar-erroraway-sonar-plugin/pom.xml
@@ -67,9 +67,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.sonarsource.java</groupId>
-			<artifactId>sonar-java-plugin</artifactId>
-			<version>${sonar-java.version}</version>
-			<scope>provided</scope>
+			<artifactId>java-frontend</artifactId>
+			<version>${sonar-java-frontend.version}</version>
 		</dependency>
 		
 		<dependency>

--- a/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
+++ b/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,10 +117,10 @@ class ErrorAwaySensorTest {
 		dependencyManager = new ErrorAwayDependencyManager(tempFolder, configuration);
 
 		// Sample data
-		FilePredicate javaFilePredicate = inputFile -> inputFile.filename().endsWith("java");
-		FilePredicate mainFilePredicate = inputFile -> inputFile.type() == Type.MAIN;
-		mainJavaFilePredicate = inputFile -> javaFilePredicate.apply(inputFile) && mainFilePredicate.apply(inputFile);
-		uriFilePredicate = inputFile -> inputFile.uri().equals(inputFile.uri());
+		FilePredicate javaFilePredicate = file -> file.filename().endsWith("java");
+		FilePredicate mainFilePredicate = file -> file.type() == Type.MAIN;
+		mainJavaFilePredicate = file -> javaFilePredicate.apply(file) && mainFilePredicate.apply(file);
+		uriFilePredicate = file -> file.uri().equals(file.uri());
 		inputFile = new TestInputFile(path.resolve(relativePath), relativePath, charset, Type.MAIN);
 		Iterable<InputFile> inputFiles = Collections.singleton(inputFile);
 
@@ -309,7 +308,7 @@ class ErrorAwaySensorTest {
 		ErrorAwaySensor sensor = new ErrorAwaySensor(dependencyManager, tempFolder);
 		sensor.execute(context);
 
-		assertThat(logTester.getLogs(Level.WARN).stream().map(LogAndArguments::getRawMsg).collect(Collectors.toList())).contains("Could not file input file for source {}");
+		assertThat(logTester.getLogs(Level.WARN).stream().map(LogAndArguments::getRawMsg).toList()).contains("Could not file input file for source {}");
 	}
 
 	@Test

--- a/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
+++ b/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/ErrorAwaySensorTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -125,7 +124,6 @@ class ErrorAwaySensorTest {
 		uriFilePredicate = inputFile -> inputFile.uri().equals(inputFile.uri());
 		inputFile = new TestInputFile(path.resolve(relativePath), relativePath, charset, Type.MAIN);
 		Iterable<InputFile> inputFiles = Collections.singleton(inputFile);
-		Collection<File> classpath = Collections.singleton(new File(System.getProperty("java.home") + "/lib/jrt-fs.jar"));
 
 		// Mock some methods
 		when(context.config()).thenReturn(configuration);

--- a/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/it/ErrorAwayIT.java
+++ b/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/it/ErrorAwayIT.java
@@ -52,7 +52,7 @@ import com.sonar.orchestrator.locator.FileLocation;
 public class ErrorAwayIT {
 
 	private static final String SIMPLE_MAVEN_PROJECT_KEY = "sonar-error-away-plugin:simple";
-    private static final String SIMPLE_GRADLE_PROJECT_KEY = "sonar-error-away-plugin:gradle-simple";
+	private static final String SIMPLE_GRADLE_PROJECT_KEY = "sonar-error-away-plugin:gradle-simple";
 
 	private static Orchestrator ORCHESTRATOR;
 
@@ -83,30 +83,30 @@ public class ErrorAwayIT {
 		PROJECT_SERVICES = new ProjectsService(connector);
 		ISSUES_SERVICES = new IssuesService(connector);
 	}
-	
+
 	private static String getSonarWebPort() {
 		return System.getProperty("sonar.web.port", "9000");
 	}
-	
+
 	@AfterAll
 	public static void stopOrchestrator() {
 		ORCHESTRATOR.stop();
 	}
 
-    private void setupProjectAndProfile(String projectKey, String projectName) {
-        // Create the sample project
-        CreateRequest createRequest = new CreateRequest();
-        createRequest.setName(projectName);
-        createRequest.setProject(projectKey);
-        PROJECT_SERVICES.create(createRequest);
+	private void setupProjectAndProfile(String projectKey, String projectName) {
+		// Create the sample project
+		CreateRequest createRequest = new CreateRequest();
+		createRequest.setName(projectName);
+		createRequest.setProject(projectKey);
+		PROJECT_SERVICES.create(createRequest);
 
-        // Enable the quality profile
-        AddProjectRequest addProjectRequest = new AddProjectRequest();
-        addProjectRequest.setLanguage("java");
-        addProjectRequest.setProject(projectKey);
-        addProjectRequest.setQualityProfile(ErrorAwayQualityProfile.ERROR_PRONE_AND_PLUGINS_PROFILE_NAME);
-        QUALITY_PROFILES_SERVICE.addProject(addProjectRequest);
-    }
+		// Enable the quality profile
+		AddProjectRequest addProjectRequest = new AddProjectRequest();
+		addProjectRequest.setLanguage("java");
+		addProjectRequest.setProject(projectKey);
+		addProjectRequest.setQualityProfile(ErrorAwayQualityProfile.ERROR_PRONE_AND_PLUGINS_PROFILE_NAME);
+		QUALITY_PROFILES_SERVICE.addProject(addProjectRequest);
+	}
 
 	@Test
 	void analyzeSimpleMavenProject() {
@@ -120,9 +120,9 @@ public class ErrorAwayIT {
 				.setProperty("sonar.password", "admin")
 				.setProperty("sonar.web.port", getSonarWebPort())
 				.setGoals("clean package org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.plugins.downloadOnlyRequired=false");
-		
+
 		ORCHESTRATOR.executeBuild(build);
-		
+
 		checkIssues(SIMPLE_MAVEN_PROJECT_KEY);
 	}
 
@@ -146,7 +146,7 @@ public class ErrorAwayIT {
 
 		checkIssues(SIMPLE_GRADLE_PROJECT_KEY);
 	}
-	
+
 	private void checkIssues(String projectKey) {
 		// Check the issues reported in SonarQube
 		SearchRequest issueRequest = new SearchRequest();
@@ -166,7 +166,7 @@ public class ErrorAwayIT {
 	@SuppressWarnings("unchecked")
 	private void assertSimpleIssues(List<Issue> issues, String projectKey) {
 		Predicate<Issue> simpleJavaPredicate = component(projectKey, "src/main/java/Simple.java");
-	
+
 		assertThatIssuesContainsIssueMatching(issues, simpleJavaPredicate, rule("errorprone:DefaultPackage"), startLine(1));
 		assertThatIssuesContainsIssueMatching(issues, simpleJavaPredicate, rule("errorprone-slf4j:Slf4jLoggerShouldBePrivate"), startLine(8));
 		assertThatIssuesContainsIssueMatching(issues, simpleJavaPredicate, rule("errorprone:ClassNewInstance"), startLine(11));
@@ -218,7 +218,7 @@ public class ErrorAwayIT {
 	@SuppressWarnings("unchecked")
 	private void assertThatIssuesContainsIssueMatching(List<Issue> issues, Predicate<Issue>... issuePredicates) {
 		Predicate<Issue> issuePredicate = i -> Stream.of(issuePredicates).allMatch(p -> p.test(i));
-		
+
 		assertThat(issues).anyMatch(issuePredicate);
 	}
 

--- a/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/it/ErrorAwayIT.java
+++ b/sonar-erroraway-sonar-plugin/src/test/java/com/github/erroraway/sonarqube/it/ErrorAwayIT.java
@@ -69,7 +69,6 @@ public class ErrorAwayIT {
 				.useDefaultAdminCredentialsForBuilds(true)
 				.addPlugin(FileLocation.of("./target/sonar-erroraway-plugin.jar"))
 				.keepBundledPlugins()
-				.setServerProperty("sonar.plugins.downloadOnlyRequired", "false")
 				.setOrchestratorProperty("orchestrator.artifactory.url", "https://repo1.maven.org/maven2")
 				.setServerProperty("sonar.web.port", getSonarWebPort())
 				.setSonarVersion("LATEST_RELEASE[" + sonarVersion + "]");


### PR DESCRIPTION
Since SQ 10.6 the sonar-java plugin isn't on the plugin's classpath when SQ is configured to only download the required plugins.