### PR TITLE
Check the maven plugin failure cases

### DIFF
--- a/sonar-erroraway-maven-plugin/infinitest.args
+++ b/sonar-erroraway-maven-plugin/infinitest.args
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/sonar-erroraway-maven-plugin/pom.xml
+++ b/sonar-erroraway-maven-plugin/pom.xml
@@ -115,5 +115,11 @@
  				<version>3.8.2</version>
 			</plugin>
 		</plugins>
+		
+		<testResources>
+			<testResource>
+				<directory>${project.basedir}/../sonar-erroraway-sonar-plugin/src/main/resources/</directory>
+			</testResource>
+		</testResources>
 	</build>
 </project>

--- a/sonar-erroraway-maven-plugin/src/test/java/com/github/erroraway/maven/ErrorAwayRulesMojoTest.java
+++ b/sonar-erroraway-maven-plugin/src/test/java/com/github/erroraway/maven/ErrorAwayRulesMojoTest.java
@@ -1,8 +1,16 @@
 package com.github.erroraway.maven;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +20,19 @@ class ErrorAwayRulesMojoTest {
 	void execute() {
 		ErrorAwayRulesMojo mojo = new ErrorAwayRulesMojo();
 		mojo.outputDirectory = new File("target/test/metadata");
-		
+
 		assertDoesNotThrow(mojo::execute);
+	}
+
+	@Test
+	void handleDescriptionReadException() throws Exception {
+		ErrorAwayRulesMojo mojo = spy(ErrorAwayRulesMojo.class);
+		mojo.outputDirectory = new File("target/test/metadata");
+
+		when(mojo.findDescriptionResource(anyString())).thenReturn(new URL("file://doesnotexist"));
+
+		assertThatCode(mojo::execute).hasMessageStartingWith("Error parsing MD description");
+
+		verify(mojo, times(1)).handleDescriptionReadException(anyString(), any());
 	}
 }


### PR DESCRIPTION
- Added the documentation folder to the test classpath so the plugin can generate metadata during tests
- Test the case when a rule description fails to load