### PR TITLE
Revert sonar plugin key to errorawaysonar

### DIFF
--- a/sonar-erroraway-sonar-plugin/pom.xml
+++ b/sonar-erroraway-sonar-plugin/pom.xml
@@ -239,7 +239,7 @@
 				<version>1.21.0.505</version>
 				<extensions>true</extensions>
 				<configuration>
-					<pluginKey>erroraway</pluginKey>
+					<pluginKey>errorawaysonar</pluginKey>
 					<pluginClass>com.github.erroraway.sonarqube.ErrorAwayPlugin</pluginClass>
 					<pluginName>ErrorAway</pluginName>
 					<pluginDescription>Analyze Java Code with ErrorProne, NullAway, errorprone-slf4j and Picnic ErrorProne support</pluginDescription>


### PR DESCRIPTION
The plugin is now published on the market place with key `errorawaysonar`, see https://github.com/SonarSource/sonar-update-center-properties/pull/721